### PR TITLE
Fixing Maven distribution URLs

### DIFF
--- a/lib/util.lua
+++ b/lib/util.lua
@@ -3,9 +3,9 @@ local http = require("http")
 local util = {}
 
 
-util.MAVEN_URL = "https://dlcdn.apache.org/dist/maven/"
-util.FILE_URL = "https://dlcdn.apache.org/dist/maven/maven-%s/%s/binaries/apache-maven-%s-bin.tar.gz"
-util.CHECKSUM_URL = "https://dlcdn.apache.org/dist/maven/maven-%s/%s/binaries/apache-maven-%s-bin.tar.gz.%s"
+util.MAVEN_URL = "https://dlcdn.apache.org/maven/"
+util.FILE_URL = "https://dlcdn.apache.org/maven/maven-%s/%s/binaries/apache-maven-%s-bin.tar.gz"
+util.CHECKSUM_URL = "https://dlcdn.apache.org/maven/maven-%s/%s/binaries/apache-maven-%s-bin.tar.gz.%s"
 
 function util:parseVersion(path)
     local resp, err = http.get({

--- a/lib/util.lua
+++ b/lib/util.lua
@@ -3,9 +3,9 @@ local http = require("http")
 local util = {}
 
 
-util.MAVEN_URL = "https://archive.apache.org/dist/maven/"
-util.FILE_URL = "https://archive.apache.org/dist/maven/maven-%s/%s/binaries/apache-maven-%s-bin.tar.gz"
-util.CHECKSUM_URL = "https://archive.apache.org/dist/maven/maven-%s/%s/binaries/apache-maven-%s-bin.tar.gz.%s"
+util.MAVEN_URL = "https://dlcdn.apache.org/dist/maven/"
+util.FILE_URL = "https://dlcdn.apache.org/dist/maven/maven-%s/%s/binaries/apache-maven-%s-bin.tar.gz"
+util.CHECKSUM_URL = "https://dlcdn.apache.org/dist/maven/maven-%s/%s/binaries/apache-maven-%s-bin.tar.gz.%s"
 
 function util:parseVersion(path)
     local resp, err = http.get({


### PR DESCRIPTION
This pull request updates the Maven download URLs in the `lib/util.lua` utility module to use the new official Apache Maven CDN endpoint instead of the old archive URL. This ensures that future downloads use the most up-to-date and reliable source.

**Infrastructure update:**

* Updated the `MAVEN_URL`, `FILE_URL`, and `CHECKSUM_URL` constants in `lib/util.lua` to use `https://dlcdn.apache.org/maven/` instead of the deprecated `https://archive.apache.org/dist/maven/` endpoint.

* In fact, the https://archive.apache.org/dist/maven/ endpoint doesn't work anymore.